### PR TITLE
Center-align multi-line figure captions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This Sphinx extension fixes:
     - an issue where the size of code in a header is not the correct font size. Fix through css.
     - an issue where the sidebar shows a scrollbar even if that's not needed
     - an issue where the margin causes a scroll bar for a window between 992 and 1200px.
+    - an issue where the caption text of a figure is aligned on the left for multi-line caption text
 - with a `button` patch:
     - an issue where two buttons for interactive matplotlib widget do not appear.
 - with a `mathjax` patch:

--- a/src/jupyterbook_patches/patches/_static/fix_align_text_captions.css
+++ b/src/jupyterbook_patches/patches/_static/fix_align_text_captions.css
@@ -1,0 +1,3 @@
+figure figcaption p {
+    text-align: center !important; /* Always enforce center alignment */
+}

--- a/src/jupyterbook_patches/patches/layout.py
+++ b/src/jupyterbook_patches/patches/layout.py
@@ -11,3 +11,4 @@ class DarkModePatch(BasePatch):
         app.add_css_file(filename="fix_code_header_style.css")
         app.add_css_file(filename="fix_sidebar_scroll.css")
         app.add_css_file(filename="fix_margin.css")
+        app.add_css_file(filename="fix_align_text_captions.css")


### PR DESCRIPTION
Added a CSS patch to center-align multi-line figure captions in JupyterBook. Updated the README and layout.py to document and include the new patch.