### PR TITLE
new patch to improve the download experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This Sphinx extension fixes:
     - an issue where two buttons for interactive matplotlib widget do not appear.
 - with a `mathjax` patch:
     - an issue where in the Firefox browser the CHTML renderer of MathJax does not render thin lines consistently. Fixed by selecting the SVG renderer *only* for the Firefox browser. 
+- with a `download` patch:
+    - an issue where the standard download button for downloading `.ipynb` and `.md` files opens a new tab instead of downloading the file. Fixed by adding the `download` attribute to the download links.
 
 ## Installation
 To install the Sphinx-JupyterBook-Patches, follow these steps:

--- a/src/jupyterbook_patches/patches/_static/download_patch.js
+++ b/src/jupyterbook_patches/patches/_static/download_patch.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', function() {
+    console.log('force download is enabled!');
+    const dropdown = document.querySelector('.dropdown-download-buttons');
+    if (dropdown) {
+        dropdown.querySelectorAll('a').forEach(a => {
+        const href = a.getAttribute('href');
+        if (href && (href.endsWith('.md') || href.endsWith('.ipynb'))) {
+            console.log(`Adding download attribute to ${href}`);
+            if (!a.hasAttribute('download')) {
+                a.setAttribute('download', '');
+            }
+        }
+        });
+    }
+});

--- a/src/jupyterbook_patches/patches/download_patch.py
+++ b/src/jupyterbook_patches/patches/download_patch.py
@@ -1,0 +1,16 @@
+from jupyterbook_patches.patches import BasePatch, logger
+from sphinx.application import Sphinx
+
+class DownloadPatch(BasePatch):
+    name = "download"
+
+    def initialize(self, app):
+        logger.info("Initializing Download patch")
+        app.add_js_file(filename="download_patch.js")
+        app.connect('builder-inited', set_download_path)
+
+def set_download_path(app: Sphinx):
+
+    app.config.download_path = 'download_patch.js'
+
+    pass


### PR DESCRIPTION
This pull request introduces a new patch to improve the download experience for `.ipynb` and `.md` files in Sphinx-JupyterBook. The patch ensures that clicking the download button directly downloads the file instead of opening it in a new tab. The most important changes are grouped below:

Download functionality improvements:

* Added a new JavaScript file, `download_patch.js`, which adds the `download` attribute to download links for `.ipynb` and `.md` files, ensuring files are downloaded instead of opened in a new tab.
* Introduced a new Python patch class, `DownloadPatch`, that registers the JavaScript file with Sphinx and connects it to the build process.

Documentation updates:

* Updated the `README.md` to document the new download patch and its purpose.