### PR TITLE
Add hash jump patch to fix anchor scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This Sphinx extension fixes:
     - an issue where in the Firefox browser the CHTML renderer of MathJax does not render thin lines consistently. Fixed by selecting the SVG renderer *only* for the Firefox browser. 
 - with a `download` patch:
     - an issue where the standard download button for downloading `.ipynb` and `.md` files opens a new tab in some browsers instead of downloading the file. Fixed by adding the `download` attribute to the download links.
+- with a `hash` patch:
+    - an issue where if the URL contains a specific element id, the page scrolls to the element on the initial/partial page load and does not scroll to that element after complete page load. Fixed by adding a small javascript that scrolls to the element after complete page load.
 
 ## Installation
 To install the Sphinx-JupyterBook-Patches, follow these steps:

--- a/src/jupyterbook_patches/patches/_static/fix_hash_jump.js
+++ b/src/jupyterbook_patches/patches/_static/fix_hash_jump.js
@@ -1,0 +1,9 @@
+window.addEventListener("load", function() {
+  if (window.location.hash) {
+    const id = window.location.hash.substring(1);
+    const el = document.getElementById(id);
+    if (el) {
+      el.scrollIntoView({ behavior: "instant", block: "start" });
+    }
+  }
+});

--- a/src/jupyterbook_patches/patches/fix_hash_jump.py
+++ b/src/jupyterbook_patches/patches/fix_hash_jump.py
@@ -1,0 +1,16 @@
+from jupyterbook_patches.patches import BasePatch, logger
+from sphinx.application import Sphinx
+
+class HashJumpPatch(BasePatch):
+    name = "hash"
+
+    def initialize(self, app):
+        logger.info("Initializing HashJump patch")
+        app.add_js_file(filename="fix_hash_jump.js")
+        app.connect('builder-inited',set_hash_jump_path)
+
+def set_hash_jump_path(app:Sphinx):
+
+    app.config.hash_jump_path = 'fix_hash_jump.js'
+
+    pass


### PR DESCRIPTION
Introduces a new patch that ensures pages scroll to the correct element when a URL hash is present after full page load. Adds a JavaScript file to handle the scroll and updates the README with details about the new patch.