### PR TITLE
Update mathjax_patch.css

### DIFF
--- a/src/jupyterbook_patches/patches/_static/mathjax_patch.css
+++ b/src/jupyterbook_patches/patches/_static/mathjax_patch.css
@@ -1,19 +1,3 @@
-/* Inline math */
-.bd-content mjx-container[jax="CHTML"]:not([display="true"]) {
-  vertical-align: baseline;
-  white-space: normal !important;
-  overflow: visible !important;
-  display: inline !important;
-  max-width: none !important;
+.bd-content mjx-container[jax="CHTML"] {
   line-height: 1 !important;
-}
-
-/* Display math */
-.bd-content mjx-container[jax="CHTML"][display="true"] {
-  margin: 1em 0;
-  overflow-y: visible !important;
-  display: inline !important;
-  max-width: none !important;
-  white-space: normal !important;
-  padding-top: 0.2rem !important;
 }

--- a/src/jupyterbook_patches/patches/_static/mathjax_patch.css
+++ b/src/jupyterbook_patches/patches/_static/mathjax_patch.css
@@ -1,3 +1,3 @@
 .bd-content mjx-container[jax="CHTML"] {
-  line-height: 1 !important;
+  line-height: 1.2 !important;
 }

--- a/src/jupyterbook_patches/patches/_static/mathjax_patch.css
+++ b/src/jupyterbook_patches/patches/_static/mathjax_patch.css
@@ -1,10 +1,11 @@
 /* Inline math */
-.bd-content mjx-container[jax="CHTML"][display="false"] {
+.bd-content mjx-container[jax="CHTML"]:not([display="true"]) {
   vertical-align: baseline;
   white-space: normal !important;
   overflow: visible !important;
   display: inline !important;
   max-width: none !important;
+  line-height: normal;
 }
 
 /* Display math */

--- a/src/jupyterbook_patches/patches/_static/mathjax_patch.css
+++ b/src/jupyterbook_patches/patches/_static/mathjax_patch.css
@@ -5,7 +5,7 @@
   overflow: visible !important;
   display: inline !important;
   max-width: none !important;
-  line-height: normal;
+  line-height: normal !important;
 }
 
 /* Display math */

--- a/src/jupyterbook_patches/patches/_static/mathjax_patch.css
+++ b/src/jupyterbook_patches/patches/_static/mathjax_patch.css
@@ -5,7 +5,7 @@
   overflow: visible !important;
   display: inline !important;
   max-width: none !important;
-  line-height: normal !important;
+  line-height: 1 !important;
 }
 
 /* Display math */


### PR DESCRIPTION
inline math doesn't seem to have a display argument, at least not that I could find.
The line-height: 1 default value seems to be the main issue