### PR TITLE
Enhance index generation with custom template and sticky navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ This Sphinx extension fixes:
     - The `include` directive now correctly handles included content from markdown files with top-level `code-cell`s and/or YAML front-matter from markdown files.
   - an issue where markdown files that contain and/or include top-level `code-cell`s were not ensured to be a text-based notebook file.
     - Markdown files that contain and/or include top-level `code-cell`s are ensured to be a text-based notebook file.
+- with an `index` patch:
+  - that adds a sticky jumpbox to the index page, allowing users to quickly navigate to different sections of the index.
+  - that adds a scroll-margin-top to the index headings, ensuring that when users click on a jumpbox link, the corresponding section is not hidden behind the sticky jumpbox.
+  - that sorts the multiples instances of the same index entry based on the order of the documents in the toctree, instead of sorting them alphabetically. This ensures that the index entries are displayed in a more logical and user-friendly manner.
+  - displays index entries with multiple instances in a more logical manner. In example, if the entry "foo" appears four times, the index originally displayed it as:
+    ```
+    foo, [1], [2], [3]
+    ```
+    where `foo`, `[1]`, `[2]` and `[3]` are links to the four instances of "foo". The patch now displays it as:
+    ```
+    foo [1], [2], [3], [4]
+    ```
+    
 
 ## Installation
 To install the Sphinx-JupyterBook-Patches, follow these steps:

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ This Sphinx extension fixes:
 - with an `index` patch:
   - that adds a sticky jumpbox to the index page, allowing users to quickly navigate to different sections of the index.
   - that adds a scroll-margin-top to the index headings, ensuring that when users click on a jumpbox link, the corresponding section is not hidden behind the sticky jumpbox.
-  - that sorts the multiples instances of the same index entry based on the order of the documents in the toctree, instead of sorting them alphabetically. This ensures that the index entries are displayed in a more logical and user-friendly manner.
-  - displays index entries with multiple instances in a more logical manner. In example, if the entry "foo" appears four times, the index originally displayed it as:
+  - that sorts the multiple instances of the same index entry based on the order of the documents in the toctree, instead of sorting them alphabetically. This ensures that the index entries are displayed in a more logical and user-friendly manner.
+  - displays index entries with multiple instances in a more logical manner. For example, if the entry "foo" appears four times, the index originally displayed it as:
     ```
     foo, [1], [2], [3]
     ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ authors = [
 ]
 description = "A collection of useful Jupyter Book v1 patches."
 dependencies = [
-    "sphinx"
+    "sphinx",
+    "pyyaml"
 ]
 requires-python = ">=3.9"
 

--- a/src/jupyterbook_patches/__init__.py
+++ b/src/jupyterbook_patches/__init__.py
@@ -43,8 +43,6 @@ def setup(app: Sphinx):
     app.connect("config-inited", init_patches)
     app.add_config_value("patch_config", {}, "html")
     app.connect("config-inited", set_mathjax_loading)
-    # store template_path in memory for use in index_patch.py
-
 
     return {
         "version": __version__,

--- a/src/jupyterbook_patches/__init__.py
+++ b/src/jupyterbook_patches/__init__.py
@@ -13,7 +13,7 @@ def set_static_path(app):
 
 def setup_patch_configuration(app: Sphinx,config):
     patch_config = app.config.patch_config
-    defaults = {"disabled-patches": []}
+    defaults = {"disabled-patches": [],"templates_path": str(Path(__file__).parent / "patches" / "_templates")}
 
     for key, val in defaults.items():
         if key not in patch_config:
@@ -43,6 +43,8 @@ def setup(app: Sphinx):
     app.connect("config-inited", init_patches)
     app.add_config_value("patch_config", {}, "html")
     app.connect("config-inited", set_mathjax_loading)
+    # store template_path in memory for use in index_patch.py
+
 
     return {
         "version": __version__,

--- a/src/jupyterbook_patches/patches/_static/index_patch.css
+++ b/src/jupyterbook_patches/patches/_static/index_patch.css
@@ -1,0 +1,10 @@
+.genindex-jumpbox {
+    position: sticky;
+    top: 3rem;
+    background-color: var(--pst-color-background);
+    z-index: 100;
+}
+
+h2.genindex-subheading {
+    scroll-margin-top: 2rem; /* Adjust based on .genindex-jumpbox height */
+}

--- a/src/jupyterbook_patches/patches/_templates/genindex.html
+++ b/src/jupyterbook_patches/patches/_templates/genindex.html
@@ -42,7 +42,7 @@
 </div>
 
 {%- for key, entries in genindexentries %}
-<h2 id="{{ key }}">{{ key }}</h2>
+<h2 class="genindex-subheading" id="{{ key }}">{{ key }}</h2>
 <table style="width: 100%" class="indextable genindextable"><tr>
   {%- for column in entries|slice_index(2) if column %}
   <td style="width: 33%; vertical-align: top;"><ul>

--- a/src/jupyterbook_patches/patches/_templates/genindex.html
+++ b/src/jupyterbook_patches/patches/_templates/genindex.html
@@ -1,0 +1,137 @@
+{#
+    basic/genindex.html
+    ~~~~~~~~~~~~~~~~~~~
+
+    Template for an "all-in-one" index.
+
+    :copyright: Copyright 2007-2024 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+#}
+{%- extends "layout.html" %}
+{% set title = _('Index') %}
+
+{% macro indexentries(firstname, links) %}
+  {%- if links -%}
+    <a href="{{ links[0][1] }}">
+    {%- if links[0][0] %}<strong>{% endif -%}
+    {{ firstname|e }}
+    {%- if links|length > 1 %} [1]{% endif -%}
+    {%- if links[0][0] %}</strong>{% endif -%}
+    </a>
+
+    {%- for ismain, link in links[1:] -%}
+      , <a href="{{ link }}">{% if ismain %}<strong>{% endif -%}
+      [{{ loop.index + 1 }}]
+      {%- if ismain %}</strong>{% endif -%}
+      </a>
+    {%- endfor %}
+  {%- else %}
+    {{ firstname|e }}
+  {%- endif %}
+{% endmacro %}
+
+{% block body %}
+
+<h1 id="index">{{ _('Index') }}</h1>
+
+<div class="genindex-jumpbox">
+ {% for key, dummy in genindexentries -%}
+ <a href="#{{ key }}"><strong>{{ key }}</strong></a>
+ {% if not loop.last %}| {% endif %}
+ {%- endfor %}
+</div>
+
+{%- for key, entries in genindexentries %}
+<h2 id="{{ key }}">{{ key }}</h2>
+<table style="width: 100%" class="indextable genindextable"><tr>
+  {%- for column in entries|slice_index(2) if column %}
+  <td style="width: 33%; vertical-align: top;"><ul>
+    {%- for entryname, (links, subitems, _) in column %}
+      <li>{{ indexentries(entryname, links) }}
+      {%- if subitems %}
+      <ul>
+      {%- for subentryname, subentrylinks in subitems %}
+        <li>{{ indexentries(subentryname, subentrylinks) }}</li>
+      {%- endfor %}
+      </ul>
+      {%- endif -%}</li>
+    {%- endfor %}
+  </ul></td>
+  {%- endfor %}
+</tr></table>
+{% endfor %}
+
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const prevNextArea = document.querySelector(".prev-next-area");
+  if (!prevNextArea) {
+    return;
+  }
+
+  const navLinks = Array.from(
+    document.querySelectorAll(".bd-sidebar-primary .bd-sidenav a.reference.internal")
+  );
+  if (!navLinks.length) {
+    return;
+  }
+
+  const currentIndex = navLinks.findIndex((link) =>
+    link.classList.contains("current") || link.closest("li")?.classList.contains("current")
+  );
+  if (currentIndex === -1) {
+    return;
+  }
+
+  const previous = navLinks[currentIndex - 1] || null;
+  const next = navLinks[currentIndex + 1] || null;
+
+  const buildLink = (direction, link) => {
+    if (!link || !link.getAttribute("href") || link.getAttribute("href") === "#") {
+      return "";
+    }
+
+    const title = (link.textContent || "").trim();
+    if (!title) {
+      return "";
+    }
+
+    if (direction === "previous") {
+      return `
+        <a class="left-prev" href="${link.getAttribute("href")}" title="previous page">
+          <i class="fa-solid fa-angle-left"></i>
+          <div class="prev-next-info">
+            <p class="prev-next-subtitle">previous</p>
+            <p class="prev-next-title">${title}</p>
+          </div>
+        </a>`;
+    }
+
+    return `
+      <a class="right-next" href="${link.getAttribute("href")}" title="next page">
+        <div class="prev-next-info">
+          <p class="prev-next-subtitle">next</p>
+          <p class="prev-next-title">${title}</p>
+        </div>
+        <i class="fa-solid fa-angle-right"></i>
+      </a>`;
+  };
+
+  const html = `${buildLink("previous", previous)}${buildLink("next", next)}`;
+  prevNextArea.innerHTML = html;
+});
+</script>
+
+{% endblock %}
+
+{% block sidebarrel %}
+{% if split_index %}
+   <h4>{{ _('Index') }}</h4>
+   <p>{% for key, dummy in genindexentries -%}
+   <a href="{{ pathto('genindex-' + key) }}"><strong>{{ key }}</strong></a>
+     {% if not loop.last %}| {% endif %}
+   {%- endfor %}</p>
+
+   <p><a href="{{ pathto('genindex-all') }}"><strong>{{ _('Full index on one page') }}</strong></a></p>
+{% endif %}
+   {{ super() }}
+{% endblock %}

--- a/src/jupyterbook_patches/patches/_templates/genindex.html
+++ b/src/jupyterbook_patches/patches/_templates/genindex.html
@@ -85,12 +85,20 @@ document.addEventListener("DOMContentLoaded", function () {
   const previous = navLinks[currentIndex - 1] || null;
   const next = navLinks[currentIndex + 1] || null;
 
+  const escapeHtml = (value) =>
+    value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+
   const buildLink = (direction, link) => {
     if (!link || !link.getAttribute("href") || link.getAttribute("href") === "#") {
       return "";
     }
 
-    const title = (link.textContent || "").trim();
+    const title = escapeHtml((link.textContent || "").trim());
     if (!title) {
       return "";
     }

--- a/src/jupyterbook_patches/patches/index_patch.py
+++ b/src/jupyterbook_patches/patches/index_patch.py
@@ -15,6 +15,7 @@ class IndexPatch(BasePatch):
     def initialize(self, app):
         app.connect('builder-inited', add_template_path)
         app.connect("builder-inited", patch_index)
+        app.add_css_file(filename="index_patch.css")
 
 def add_template_path(app:Sphinx, exception=None):
     if exception:

--- a/src/jupyterbook_patches/patches/index_patch.py
+++ b/src/jupyterbook_patches/patches/index_patch.py
@@ -1,18 +1,20 @@
-from pathlib import Path
-
 from jupyterbook_patches.patches import BasePatch
 from sphinx.application import Sphinx
-from jinja2.loaders import FileSystemLoader
 
-from sphinx.util import logging
+from sphinx.environment.adapters.indexentries import IndexEntries
+from pathlib import PurePosixPath
+from docutils import nodes
+import yaml
+import os
+import re
 
-logger = logging.getLogger(__name__)
 
 class IndexPatch(BasePatch):
     name = "index"
 
     def initialize(self, app):
         app.connect('builder-inited', add_template_path)
+        app.connect("builder-inited", patch_index)
 
 def add_template_path(app:Sphinx, exception=None):
     if exception:
@@ -25,4 +27,143 @@ def add_template_path(app:Sphinx, exception=None):
         for loader in app.builder.templates.loaders:
             if hasattr(loader, 'searchpath'):
                 loader.searchpath.insert(0, X)
-                logger.info(f"Updated Jinja2 loader searchpath: {loader.searchpath}", color="yellow")
+
+def patch_index(app):
+    env = app.env
+
+    # -----------------------------
+    # Build TOC document order
+    # -----------------------------
+    doc_order = build_doc_order(env)
+
+    # -----------------------------
+    # Build anchor positions per doc
+    # -----------------------------
+    anchor_positions = build_anchor_positions(env)
+
+    # -----------------------------
+    # Monkeypatch
+    # -----------------------------
+    original = IndexEntries.create_index
+
+    def custom_create_index(self, builder, group_entries=True):
+        content = original(self, builder, group_entries)
+
+        for _, entries in content:
+            for i, (term, (links, subitems, key)) in enumerate(entries):
+
+                def sort_key(link):
+                    # Current Sphinx index targets are (main, uri) pairs.
+                    _, uri = link
+
+                    if not uri:
+                        return (10**9, 10**9)
+
+                    target = uri.split("#", 1)[0]
+                    anchor = uri.split("#", 1)[1] if "#" in uri else ""
+                    docname = target[:-5] if target.endswith(".html") else target
+
+                    # 1. TOC order
+                    doc_pos = doc_order.get(docname, 10**9)
+
+                    # 2. Prefer numeric index anchors when available so same-document
+                    # entries follow their source order in the generated index.
+                    index_match = re.search(r"index-(\d+)$", anchor)
+                    if index_match:
+                        anchor_pos = (0, int(index_match.group(1)))
+                    else:
+                        anchor_map = anchor_positions.get(docname, {})
+                        anchor_pos = (1, anchor_map.get(anchor, 10**9))
+
+                    return (doc_pos, anchor_pos)
+
+                links.sort(key=sort_key)
+
+                entries[i] = (term, (links, subitems, key))
+
+        return content
+
+    IndexEntries.create_index = custom_create_index
+
+
+# --------------------------------------------------
+# Helpers
+# --------------------------------------------------
+
+def build_doc_order(env):
+    """
+    Build document order based on the external TOC file order.
+    """
+    order = {}
+    counter = [0]
+
+    def normalize_docname(path):
+        if not path:
+            return None
+        normalized = path.replace("\\", "/")
+        return str(PurePosixPath(normalized).with_suffix(""))
+
+    def add_doc(path):
+        docname = normalize_docname(path)
+        if docname and docname not in order:
+            order[docname] = counter[0]
+            counter[0] += 1
+
+    def walk_item(item):
+        if not isinstance(item, dict):
+            return
+
+        add_doc(item.get("file"))
+
+        for key in ("parts", "chapters", "sections"):
+            for child in item.get(key, []) or []:
+                walk_item(child)
+
+    toc_name = getattr(env.config, "external_toc_path", "_toc.yml")
+    toc_path = toc_name if os.path.isabs(toc_name) else os.path.join(env.app.srcdir, toc_name)
+
+    if os.path.exists(toc_path):
+        try:
+            with open(toc_path, "r", encoding="utf-8") as toc_file:
+                toc_data = yaml.safe_load(toc_file) or {}
+        except Exception as exc:
+            pass
+        else:
+            add_doc(toc_data.get("root"))
+            for part in toc_data.get("parts", []) or []:
+                walk_item(part)
+
+    # fallback: include any missing docs
+    for doc in env.found_docs:
+        if doc not in order:
+            order[doc] = counter[0]
+            counter[0] += 1
+
+    return order
+
+
+def build_anchor_positions(env):
+    """
+    Build approximate top-to-bottom order of anchors per document
+    """
+    positions = {}
+
+    for docname in env.found_docs:
+        try:
+            doctree = env.get_doctree(docname)
+        except FileNotFoundError:
+            continue
+        pos = {}
+        counter = 0
+
+        for node in doctree.traverse():
+            if not isinstance(node, nodes.Element):
+                continue
+            ids = node.get("ids", [])
+            for anchor in ids:
+                pos[anchor] = counter
+            counter += 1
+
+        positions[docname] = pos
+
+    return positions

--- a/src/jupyterbook_patches/patches/index_patch.py
+++ b/src/jupyterbook_patches/patches/index_patch.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from jupyterbook_patches.patches import BasePatch
+from sphinx.application import Sphinx
+from jinja2.loaders import FileSystemLoader
+
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
+class IndexPatch(BasePatch):
+    name = "index"
+
+    def initialize(self, app):
+        app.connect('builder-inited', add_template_path)
+
+def add_template_path(app:Sphinx, exception=None):
+    if exception:
+        return
+
+    X = app.config.patch_config["templates_path"]
+
+    # Update the Jinja2 environment's template loader
+    if hasattr(app.builder, 'templates'):
+        for loader in app.builder.templates.loaders:
+            if hasattr(loader, 'searchpath'):
+                loader.searchpath.insert(0, X)
+                logger.info(f"Updated Jinja2 loader searchpath: {loader.searchpath}", color="yellow")

--- a/src/jupyterbook_patches/patches/index_patch.py
+++ b/src/jupyterbook_patches/patches/index_patch.py
@@ -30,26 +30,28 @@ def add_template_path(app:Sphinx, exception=None):
                 loader.searchpath.insert(0, X)
 
 def patch_index(app):
-    env = app.env
-
-    # -----------------------------
-    # Build TOC document order
-    # -----------------------------
-    doc_order = build_doc_order(env)
-
-    # -----------------------------
-    # Build anchor positions per doc
-    # -----------------------------
-    anchor_positions = build_anchor_positions(env)
+    # The index is generated later in the build; defer TOC / anchor computation
+    # until create_index is called so env.found_docs / doctrees are available.
+    doc_order = None
+    anchor_positions = None
 
     # -----------------------------
     # Monkeypatch
     # -----------------------------
+    if getattr(IndexEntries, "_jupyterbook_patches_index_patched", False):
+        return
+    IndexEntries._jupyterbook_patches_index_patched = True
+
     original = IndexEntries.create_index
 
     def custom_create_index(self, builder, group_entries=True):
-        content = original(self, builder, group_entries)
+        nonlocal doc_order, anchor_positions
+        if doc_order is None or anchor_positions is None:
+            env = builder.env
+            doc_order = build_doc_order(env)
+            anchor_positions = build_anchor_positions(env)
 
+        content = original(self, builder, group_entries)
         for _, entries in content:
             for i, (term, (links, subitems, key)) in enumerate(entries):
 


### PR DESCRIPTION
This pull request introduces a significant enhancement to the Sphinx extension by adding a new "index" patch that improves the user experience and logical ordering of the generated index page. The patch provides a sticky jumpbox for quick navigation, improves the sorting and display of index entries with multiple instances, and ensures that index entries are ordered according to the table of contents (TOC) rather than alphabetically. Supporting changes include the addition of new templates, CSS, and configuration options.

**Index page improvements:**

* Added a new `index` patch that:
  - Provides a sticky jumpbox at the top of the index page for quick navigation between sections. [[1]](diffhunk://#diff-92b298074dd93fdbffebaf105688ec93fe7dae5bf93ae017b4433e26db25daccR1-R10) [[2]](diffhunk://#diff-38ed60d4c11cf72d2ea71389948b54d2c4e086f13a75865e5c3cea18c43b2d68R1-R137) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R65)
  - Adds scroll-margin to index headings so that jumpbox links do not obscure section titles. [[1]](diffhunk://#diff-92b298074dd93fdbffebaf105688ec93fe7dae5bf93ae017b4433e26db25daccR1-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R65)
  - Sorts multiple instances of the same index entry based on the TOC order, not alphabetically, for more user-friendly display. [[1]](diffhunk://#diff-a77f047c40ddcea02d59f6e0ddb7518a7873fafd4d094d939e37ead674ca4d5eR1-R170) [[2]](diffhunk://#diff-38ed60d4c11cf72d2ea71389948b54d2c4e086f13a75865e5c3cea18c43b2d68R1-R137) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R65)
  - Changes the display format for entries with multiple instances to a more logical and readable style. [[1]](diffhunk://#diff-38ed60d4c11cf72d2ea71389948b54d2c4e086f13a75865e5c3cea18c43b2d68R1-R137) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R65)

**Implementation and configuration:**

* Added a new Jinja template `genindex.html` and corresponding CSS file `index_patch.css` to support the improved index page layout and navigation. [[1]](diffhunk://#diff-38ed60d4c11cf72d2ea71389948b54d2c4e086f13a75865e5c3cea18c43b2d68R1-R137) [[2]](diffhunk://#diff-92b298074dd93fdbffebaf105688ec93fe7dae5bf93ae017b4433e26db25daccR1-R10)
* Updated the extension configuration to include a `templates_path` default, ensuring the new templates are available to Sphinx.
* Registered the patch and connected the template path and CSS file in the extension setup. [[1]](diffhunk://#diff-a77f047c40ddcea02d59f6e0ddb7518a7873fafd4d094d939e37ead674ca4d5eR1-R170) [[2]](diffhunk://#diff-342bcf44d470969747d355d14a70201b8f3b53399f4d47c490fc02b3e1b7e7d3R46-R47)

These changes collectively provide a more intuitive and navigable index page for users of the Sphinx-JupyterBook-Patches extension.